### PR TITLE
Wrong Chain ID for Rinkeby. Göerli missing?

### DIFF
--- a/docs/ethereum/builtin-chains.md
+++ b/docs/ethereum/builtin-chains.md
@@ -10,5 +10,6 @@ Brave preloads the following chains by default.
 | ----------- | -------------------- | --------------- |
 | 0x1         | Ethereum Mainnet     | ETH             |
 | 0x3         | Ropsten Testnet      | ETH             |
-| 0x5         | Rinkeby Testnet      | ETH             |
+| 0x4         | Rinkeby Testnet      | ETH             |
+| 0x5         | Görli Testnet        | ETH             |
 | 0x2a        | Kovan Testnet        | ETH             |


### PR DESCRIPTION
Rinkeby is chain id 0x4, Görli is chain 0x5. I believe both of them are part of the default list (it is the case for Metamask and Brave's Cryptowallets).