### PR TITLE
Add isBraveWallet detection code snippet

### DIFF
--- a/docs/ethereum/wallet-detection.md
+++ b/docs/ethereum/wallet-detection.md
@@ -19,3 +19,10 @@ const isBraveWallet = await window.ethereum.request({
   })
 console.log('Brave Wallet: ', isBraveWallet)
 ```
+
+
+Simplified detection (currently only available in Brave Browser Beta):
+
+```js
+const isBraveWallet = window.ethereum.isBraveWallet
+```

--- a/docs/ethereum/wallet-detection.md
+++ b/docs/ethereum/wallet-detection.md
@@ -2,14 +2,33 @@
 sidebar_position: 4
 ---
 
-# Wallet detection
+# Brave Wallet detection
 
 We recommend that Dapps use a Brave Wallet button and that they treat Brave Wallet like MetaMask.
 
-Detecting Brave:
+## Compatability with MetaMask
 
-Since Brave Wallet aims to be compatible with MetaMask's exposed API we set `window.ethereum.isMetaMask` to `true`.
-However, one can use `web3_clientVersion` to check for Brave Wallet.
+Since Brave Wallet aims to be compatible with MetaMask's exposed API, we set `window.ethereum.isMetaMask` to `true`.
+
+## Synchronous detection
+
+```js
+const isBraveWallet = window.ethereum.isBraveWallet
+console.log('Brave Wallet: ', isBraveWallet)
+```
+
+## Asynchronous detection using `web3_clientVersion`
+
+```js
+const isBraveWallet = await window.ethereum.request({
+    method: 'web3_clientVersion'
+  }).then((clientVersion) => {
+    return clientVersion.split('/')[0] === 'BraveWallet'
+  })
+console.log('Brave Wallet: ', isBraveWallet)
+```
+
+Or:
 
 ```js
 const isBraveWallet = await window.ethereum.request({
@@ -18,11 +37,4 @@ const isBraveWallet = await window.ethereum.request({
     return window.ethereum.isMetaMask && clientVersion.split('/')[0] !== 'MetaMask'
   })
 console.log('Brave Wallet: ', isBraveWallet)
-```
-
-
-Simplified detection (currently only available in Brave Browser Beta):
-
-```js
-const isBraveWallet = window.ethereum.isBraveWallet
 ```


### PR DESCRIPTION
Add example of how to use `window.ethereum.isBraveWallet` to detect Brave Wallet in Beta versions of Brave Browser.