### PR TITLE
deprecate eth_decrypt and eth_getEncryptionKey

### DIFF
--- a/docs/ethereum/rpc-api/methods.md
+++ b/docs/ethereum/rpc-api/methods.md
@@ -52,7 +52,7 @@ interface WatchAssetParameters {
 }
 ```
 
-## `eth_getEncryptionPublicKey`
+## `eth_getEncryptionPublicKey` (deprecated)
 
 Requests that the user shares their public encryption key. Returns a Promise that resolve to the public encryption key, or rejects if the user denied the request.
 
@@ -152,7 +152,7 @@ ethereum
 
 It will popup the UI to decrypt the message for the user. And if you press approve it will send it back to the Dapp. Check the JS console in dev tools to see.
 
-## `eth_decrypt`
+## `eth_decrypt` (deprecated)
 
 This method requests that Brave Wallet decrypts the given encrypted message.
 


### PR DESCRIPTION
In alignment with Metamask we've chosen to deprecate the eth_decrypt and eth_getEncryptionKey APIs due to the design of the key usage not being provably secure. Efforts are underway to define a replacement approach.

See https://medium.com/metamask/metamask-api-method-deprecation-2b0564a84686