### PR TITLE
Remove already preloaded chains in `Custom chains` and use lowercase for Arbitrum chain_id

### DIFF
--- a/docs/ethereum/custom-chains.md
+++ b/docs/ethereum/custom-chains.md
@@ -28,7 +28,7 @@ export const Add = ({children, chainId, decimals, symbol, chainName, rpcUrl, blo
       }]
       window.ethereum.request({
         method: 'wallet_addEthereumChain',
-        params  
+        params
       })
     }}>
     Add
@@ -41,7 +41,4 @@ Other chains can be added to Brave through a site like
 
 | Chain ID    | Name                 | Native currency | Decimals | Add    |
 | ----------- | -------------------- | --------------- | -------- | ------ |
-| 0x89        | Polygon Mainnet      | MATIC           | 18       | <Add decimals={18} chainId='0x89' symbol='MATIC' chainName='Polygon' rpcUrl='https://polygon-rpc.com/' blockExplorerUrl='https://polygonscan.com/' /> |
-| 0xA86A      | Avalanche Mainnet    | AVAX            | 18       | <Add decimals={18} chainId='0xA86A' symbol='AVAX' chainName='Avalanche' rpcUrl='https://api.avax.network/ext/bc/C/rpc' blockExplorerUrl='https://snowtrace.io/' /> |
-| 0x38        | Binance Smart Chain  | BNB             | 18       | <Add decimals={18} chainId='0x38' symbol='BNB' chainName='Binance Smart Chain' rpcUrl='https://bsc-dataseed1.binance.org' blockExplorerUrl='https://bscscan.com' /> |
-| 0xA4B1      | Arbitrum One         | AETH            | 18       | <Add decimals={18} chainId='0xA4B1' symbol='AETH' chainName='Arbitrum One' rpcUrl='https://arb1.arbitrum.io/rpc' blockExplorerUrl='https://arbiscan.io' /> |
+| 0xa4b1      | Arbitrum One         | AETH            | 18       | <Add decimals={18} chainId='0xa4b1' symbol='AETH' chainName='Arbitrum One' rpcUrl='https://arb1.arbitrum.io/rpc' blockExplorerUrl='https://arbiscan.io' />


### PR DESCRIPTION
I think there's no points listed them in custom chains anymore as they're already preloaded.
And use lowercase chain_id for now before because uppercase currently won't work, issue at https://github.com/brave/brave-browser/issues/25707.

<img width="1347" alt="Screen Shot 2022-09-29 at 11 29 50 AM" src="https://user-images.githubusercontent.com/4730197/193113948-4c42eb50-9c59-4441-90fa-d666e3a1ba76.png">
