### PR TITLE
Fix typo "promis" to "promise" for braveSolana.disconnect

### DIFF
--- a/docs/solana/provider-api/methods.md
+++ b/docs/solana/provider-api/methods.md
@@ -52,7 +52,7 @@ is locked.
 selected account. Note that it won't remove the granted permission in content
 settings.
 ```ts
-braveSolana.disconnect() : Promis<undefined>
+braveSolana.disconnect() : Promise<undefined>
 ```
 
 ## `braveSolana.signAndSendTransaction`


### PR DESCRIPTION
Fixes typo of "promis" to "promise". 

cc: @yrliou 