### PR TITLE
docs: fix typos

### DIFF
--- a/docs/ethereum/use-cases/sending-transactions.md
+++ b/docs/ethereum/use-cases/sending-transactions.md
@@ -51,7 +51,7 @@ For more information, see: https://eth.wiki/json-rpc/API#eth_sendtransaction
 ## eth_signTransaction and eth_sendRawTransaction
 
 Sites can request that a transaction be signed by `eth_signTransaction` method
-and send singed transaction later through `eth_sendRawTransaction` or other
+and send signed transaction later through `eth_sendRawTransaction` or other
 preferred methods.
 
 ```js

--- a/docs/ethereum/wallet-detection.md
+++ b/docs/ethereum/wallet-detection.md
@@ -8,7 +8,7 @@ We recommend that Dapps use a Brave Wallet button and that they treat Brave Wall
 
 [Web3Modal](https://github.com/Web3Modal/web3modal) is a useful library for handling this for you.
 
-## Compatability with MetaMask
+## Compatibility with MetaMask
 
 Since Brave Wallet aims to be compatible with MetaMask's exposed API, we set `window.ethereum.isMetaMask` to `true`.
 

--- a/docs/solana/provider-api/provider-detection.md
+++ b/docs/solana/provider-api/provider-detection.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Brave Wallet detection
 
-## Compatability with Phantom
+## Compatibility with Phantom
 
 Since Brave Wallet aims to be compatible with Phantom's exposed API, we set `window.braveSolana.isPhantom` to `true`.
 Also `window.solana` is an alias of `window.braveSolana`.


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `docs/ethereum/use-cases/sending-transactions.md`
1 typo in `docs/ethereum/wallet-detection.md`
1 typo in `docs/solana/provider-api/provider-detection.md`


Best!