### PR TITLE
chore: Update community domain name

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,6 +11,6 @@ Welcome to Brave Wallet's developer documentation.
 ## Resources
 
 - Brave Wallet is part of the [Brave Browser](https://brave.com/download/).
-- For questions please visit our [community site](https://community.brave.com/c/support-and-troubleshooting/wallet/131).
+- For questions please visit our [community site](https://community.brave.app/c/support-and-troubleshooting/wallet/131).
 - Follow Brave on [Twitter](https://twitter.com/brave) and [Facebook](https://www.facebook.com/BraveSoftware).
 - Post issues directly to the developers on Brave's [GitHub repo](https://github.com/brave/brave-browser/issues/new/choose).


### PR DESCRIPTION
For https://github.com/brave/devops/issues/13832

The redirect is included, so all the links will still work. Merge at your convenience.