### PR TITLE
docs: providers are only injected once a wallet is created

### DIFF
--- a/docs/cardano/overview.md
+++ b/docs/cardano/overview.md
@@ -7,7 +7,7 @@ slug: /cardano
 
 Brave Wallet implements the [Cardano dApp-Wallet Web Bridge (CIP-30)](https://cips.cardano.org/cip/CIP-30) specification, which defines a webpage-based communication bridge allowing dApps to interface with Cardano wallets.
 
-Brave injects a `window.cardano` provider object on secure sites [in these cases](/provider-availability). Under this namespace, Brave Wallet exposes its API at `cardano.brave`.
+Brave injects a `window.cardano` provider object on secure sites [in these cases](/provider-availability). Starting in Brave 1.95, this requires that the user has created a Brave Wallet. Under this namespace, Brave Wallet exposes its API at `cardano.brave`.
 
 This object gives websites the ability to:
 - Request user permission to connect and access wallet information

--- a/docs/cardano/provider-api/provider-detection.md
+++ b/docs/cardano/provider-api/provider-detection.md
@@ -8,6 +8,10 @@ sidebar_position: 1
 
 Per [CIP-30](https://cips.cardano.org/cip/CIP-30), each wallet implementing the standard creates a namespaced field under the shared `window.cardano` object. Brave Wallet uses the namespace `brave`, so the wallet object is available at `window.cardano.brave`.
 
+## No provider until a wallet is created
+
+Starting in Brave 1.95, `window.cardano` is not injected at all until the user has created a Brave Wallet, and a site has no way to prompt them to create one. A missing namespace therefore means "no wallet created yet", not "not Brave" — see [restrictions for providers](/provider-availability).
+
 ## Synchronous detection
 
 ```js

--- a/docs/default-wallet.md
+++ b/docs/default-wallet.md
@@ -8,7 +8,9 @@ We expose a setting in `brave://settings/wallet` to control how Brave makes the 
 
 Since extensions sometimes also provide these objects, this setting will help decide which wallet handles these objects.
 
-Here's a description of each setting:
+Starting in Brave 1.95, this setting only takes effect once the user has created a Brave Wallet. Until then Brave injects no provider objects regardless of which option is selected — see [restrictions for providers](/provider-availability).
+
+Here's a description of each setting (each assumes a wallet has been created):
 - `Extensions (Brave Wallet fallback)` - This is the default. Brave Wallet will expose `window.ethereum` and `window.braveSolana` but allow other extensions such as MetaMask to overwrite it.
 - `Brave Wallet` - Exposes `window.ethereum` and `window.braveSolana` and prevents sites and extensions from changing them.
 - `Extensions (no fallback)` - `window.ethereum` and `window.braveSolana` will not be provided by Brave Wallet at all. If you have enabled an extension such as MetaMask, it is free to use the provider object.

--- a/docs/ethereum/overview.md
+++ b/docs/ethereum/overview.md
@@ -5,7 +5,7 @@ slug: /ethereum
 
 # Overview
 
-Brave injects a `window.ethereum` provider object on secure sites [in these cases](/provider-availability).
+Brave injects a `window.ethereum` provider object on secure sites [in these cases](/provider-availability). Starting in Brave 1.95, this requires that the user has created a Brave Wallet.
 
 This object is defined by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193).
 

--- a/docs/ethereum/use-cases/connecting-your-site.md
+++ b/docs/ethereum/use-cases/connecting-your-site.md
@@ -29,7 +29,7 @@ Signing transactions and messages require separate user confirmations after the 
 Permissions can be revoked in `brave://settings/content/ethereum`.
 A user can also open up the wallet panel and disconnect a connected site when they are on that site.
 
-If a wallet is not yet setup and a page requests permissions, Brave opens `brave://wallet` for the user to setup the wallet.
+Starting in Brave 1.95, if a wallet is not yet setup then `window.ethereum` is `undefined`, so a site cannot request permissions at all and cannot prompt the user to set up the wallet. Sites should [detect the provider](/ethereum/wallet-detection) before calling it. Before Brave 1.95, requesting permissions without a wallet setup would open `brave://wallet` for the user to setup the wallet.
 
 # Brave logos
 

--- a/docs/ethereum/wallet-detection.md
+++ b/docs/ethereum/wallet-detection.md
@@ -18,31 +18,37 @@ Check out these open-source libraries for off-the-shelf solutions
 - [wagmi](https://github.com/tmm/wagmi)
 
 
+## No provider until a wallet is created
+
+Starting in Brave 1.95, `window.ethereum` (and `window.braveEthereum`) is `undefined` until the user has created a Brave Wallet, and a site has no way to prompt them to create one. A missing provider therefore means "no wallet created yet", not "not Brave" — see [restrictions for providers](/provider-availability).
+
+Because of this, detection must not assume `window.ethereum` exists. The examples below use optional chaining accordingly.
+
 ## Synchronous detection
 
 ```js
-const isBraveWallet = window.ethereum.isBraveWallet
+const isBraveWallet = window.ethereum?.isBraveWallet === true
 console.log('Brave Wallet: ', isBraveWallet)
 ```
 
 ## Asynchronous detection using `web3_clientVersion`
 
 ```js
-const isBraveWallet = await window.ethereum.request({
+const isBraveWallet = await window.ethereum?.request({
     method: 'web3_clientVersion'
   }).then((clientVersion) => {
     return clientVersion.split('/')[0] === 'BraveWallet'
   })
-console.log('Brave Wallet: ', isBraveWallet)
+console.log('Brave Wallet: ', isBraveWallet === true)
 ```
 
 Or:
 
 ```js
-const isBraveWallet = await window.ethereum.request({
+const isBraveWallet = await window.ethereum?.request({
     method: 'web3_clientVersion'
   }).then((clientVersion) => {
     return window.ethereum.isMetaMask && clientVersion.split('/')[0] !== 'MetaMask'
   })
-console.log('Brave Wallet: ', isBraveWallet)
+console.log('Brave Wallet: ', isBraveWallet === true)
 ```

--- a/docs/provider-availability.md
+++ b/docs/provider-availability.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 ---
 
 # Restrictions for providers
-The provider objects (e.g. `window.ethereum` and `window.braveSolana`) are not provided in all contexts.
+The provider objects (e.g. `window.ethereum`, `window.braveSolana` and `window.cardano`) are not provided in all contexts.
 
 Historically the web has had a notion of “powerful" APIs like geolocation and camera/microphone, which are subject to additional security restrictions. See for instance https://www.w3.org/TR/secure-contexts/. 
 
@@ -12,6 +12,14 @@ As a rule of thumb, if a context is not allowed to request access to geolocation
 
 Provider objects are not accessible in private and Tor window.
 
+## Restrictions until a wallet is created
+
+Starting in **Brave 1.95**, no provider object is injected until the user has created a Brave Wallet.
+Until then `window.ethereum`, `window.braveEthereum`, `window.braveSolana`, `window.solana` and `window.cardano` are all `undefined`, and there is no way for a site to prompt the user to set up the wallet.
+
+Before Brave 1.95, `window.braveEthereum`, `window.braveSolana`, `window.solana` and `window.cardano` were injected even with no wallet created (as was `window.ethereum`, when no MetaMask was installed), and requesting permissions from a site would open the wallet onboarding page.
+
+This means detection code must tolerate a missing provider rather than assume one is present. See the detection pages for [Ethereum](/ethereum/wallet-detection), [Solana](/solana/provider-api/provider-detection) and [Cardano](/cardano/provider-api/provider-detection).
 
 ## Restrictions for insecure contexts
 

--- a/docs/solana/overview.md
+++ b/docs/solana/overview.md
@@ -10,7 +10,7 @@ Brave creates Ed25519 keypairs following
 derivation path `m/44'/501'/{index}'/0'` for each accounts in
 [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
 
-Brave injects a `window.braveSolana` provider object on secure sites [in these cases](/provider-availability).
+Brave injects a `window.braveSolana` provider object on secure sites [in these cases](/provider-availability). Starting in Brave 1.95, this requires that the user has created a Brave Wallet.
 Alias `window.solana` is kept for compatibility.
 
 dApps can use this provider object to:

--- a/docs/solana/provider-api/provider-detection.md
+++ b/docs/solana/provider-api/provider-detection.md
@@ -9,10 +9,14 @@ sidebar_position: 1
 Since Brave Wallet aims to be compatible with Phantom's exposed API, we set `window.braveSolana.isPhantom` to `true`.
 Also `window.solana` is an alias of `window.braveSolana`.
 
+## No provider until a wallet is created
+
+Starting in Brave 1.95, `window.braveSolana` (and its `window.solana` alias) is `undefined` until the user has created a Brave Wallet, and a site has no way to prompt them to create one. A missing provider therefore means "no wallet created yet", not "not Brave" — see [restrictions for providers](/provider-availability).
+
 ## Synchronous detection
 
 ```js
-const isBraveWallet = window.braveSolana.isBraveWallet
+const isBraveWallet = window.braveSolana?.isBraveWallet === true
 console.log('Brave Wallet: ', isBraveWallet)
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12328,9 +12328,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3384,6 +3384,19 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/mdx-loader/node_modules/image-size": {
+      "name": "image-size-next",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/image-size-next/-/image-size-next-2.1.1.tgz",
+      "integrity": "sha512-n+DFjUct+G9mxZck+lvzqrTsqBJvSHMs6iEo//W5iAgRV7oUbrh1JWmKgAEpmyRB5lw6plIQizS1wK1dvrsvAw==",
+      "license": "MIT",
+      "bin": {
+        "image-size-next": "bin/image-size-next.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@docusaurus/module-type-aliases": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
@@ -9149,18 +9162,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "serialize-javascript": "7.0.6",
     "uuid": "^14.0.0",
     "js-yaml": "^5.0.0",
-    "gray-matter": "npm:@11ty/gray-matter@^2.0.2"
+    "gray-matter": "npm:@11ty/gray-matter@^2.0.2",
+    "image-size": "npm:image-size-next@2.1.1"
   },
   "description": "The Brave Wallet documentation website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.",
   "main": "babel.config.js",


### PR DESCRIPTION
Documents the behavior change in brave/brave-core#39127, which stops injecting `window.ethereum`, `window.braveEthereum`, `window.braveSolana`/`window.solana` and `window.cardano` until the user has created a wallet, and removes the site-triggered wallet onboarding path.

Changes are phrased as "starting in Brave 1.95", with the previous behavior stated alongside so readers on older versions aren't stranded.

## Test plan

- [x] `npm run build` passes with no broken-link warnings and `npm run serve` looks right
- [x] Confirm the version number is right — this assumes brave/brave-core#39127 lands in 1.95.x; needs updating if it slips